### PR TITLE
[ci skip] adding user @naschmitz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @arian487 @bengalin @dag-ee @dotstarmoney @joannalcy @michaelfdewitt @mike-d-d @saicheems @sufyanAbbasi @twotabbies @tylere
+* @naschmitz @arian487 @bengalin @dag-ee @dotstarmoney @joannalcy @michaelfdewitt @mike-d-d @saicheems @sufyanAbbasi @twotabbies @tylere

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - naschmitz
     - arian487
     - bengalin
     - dag-ee


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @naschmitz as instructed in #169.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #169