### PR TITLE
recipe/meta.yaml: Remove former team members

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,5 +59,4 @@ extra:
     - michaelfdewitt
     - schwehr
     - sufyanAbbasi
-    - twotabbies
     - jgarcia525


### PR DESCRIPTION
Should fix https://github.com/orgs/conda-forge/teams/earthengine-api
